### PR TITLE
Avoid redundant loading of ugens

### DIFF
--- a/src/overtone/sc/machinery/ugen/intern_ns.clj
+++ b/src/overtone/sc/machinery/ugen/intern_ns.clj
@@ -1,9 +1,0 @@
-(ns
-    ^{:doc "empty ns to intern ugens so that the ugen machinery can populate the atom overloaded-ugens* before the with-overloaded-ugens macro is used."}
-    overtone.sc.machinery.ugen.intern-ns)
-
-
-(defn ugen-intern-ns
-  "Returns the namespace to intern ugens into when loading up fn-gen for the first time."
-  []
-  'overtone.sc.machinery.ugen.intern-ns)

--- a/src/overtone/sc/ugen_collide.clj
+++ b/src/overtone/sc/ugen_collide.clj
@@ -1,0 +1,2 @@
+(ns overtone.sc.ugen-collide
+  (:refer-clojure :only [ns]))

--- a/src/overtone/sc/ugens.clj
+++ b/src/overtone/sc/ugens.clj
@@ -114,7 +114,7 @@
     `(let [~@bindings]
        ~@body)))
 
-;; We refer all the ugen functions here so they can be access by other
+;; We refer all the non-clashing ugen functions here so they can be accessed by other
 ;; parts of the Overtone system using a fixed namespace.  For example,
 ;; to automatically stick an Out ugen on synths that don't explicitly
 ;; use one.


### PR DESCRIPTION
Each ugen was being loaded twice when using overtone.live:
1. __intern-colliders___
  - non-colliders in overtone.sc.machinery.ugen.intern-ns
  - colliders in overtone.sc.ugen-collide
2. __INTERN-UGENS__
  - non-colliders in overtone.sc.machinery.ugen
  - colliders in overtone.sc.ugen-collide

After this commit:

1. __intern-colliders___
  - colliders in overtone.sc.ugen-collide
2. __INTERN-UGENS__
  - non-colliders in overtone.sc.machinery.ugen

overtone.sc.machinery.ugen.intern-ns is no longer needed as it was just a workaround for loading collisions earlier.